### PR TITLE
Fixing SendBird.d.ts 

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -5,9 +5,7 @@
  */
 
 declare const SendBird: SendBirdStatic;
-declare module 'SendBird' {
-  export = SendBird;
-}
+export = SendBird;
 
 type userCallback = (user: User, error: Object) => void;
 type pushSettingCallback = (response: string, error: Object) => void;
@@ -512,5 +510,3 @@ interface GroupChannelListQuery {
   customTypeFilter: string;
   next(callback: groupChannelListQueryCallback): void;
 }
-
-export default SendBird;

--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -512,3 +512,5 @@ interface GroupChannelListQuery {
   customTypeFilter: string;
   next(callback: groupChannelListQueryCallback): void;
 }
+
+export default SendBird;


### PR DESCRIPTION
https://github.com/smilefam/SendBird-SDK-JavaScript/issues/43
`export = SendBird` makes the SDK accessible via `import * as SendBird from 'sendbird';`.
Tested with typescript 2.6.1