### PR TITLE
remove react native / ionic qualifier in comment

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -81,7 +81,7 @@ interface SendBirdInstance {
   setDoNotDisturb(doNotDisturbOn: boolean, startHour: number, startMin: number, endHour: number, endMin: number, timezone: string, callback?: commonCallback): void;
   getDoNotDisturb(callback: commonCallback): void;
 
-  // Background/Foreground Appstate for push notifications in React Native / Ionic
+  // Background/foreground app state for push notifications
   setBackgroundState(): void;
   setForegroundState(): void;
 


### PR DESCRIPTION
`setBackgroundState` and `setForegroundState` aren't only for React Native and Ionic. They are vitally important for other JS apps too. For example, in a progressive web app, we need to disconnect the user when the app loses focus in order to receive push notifications.