### PR TITLE
modified README to match name of module exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SendBird-SDK-JavaScript
 # TypeScript
 Install via NPM and import like below in your TypeScript file:   
 ```javascript  
-import * as SendBird from 'SendBird';
+import * as SendBird from 'sendbird';
 var sb = new SendBird({'appId': 'APP_ID'});
 // do something...
 ```  


### PR DESCRIPTION
Modified example import statement in README to match the name of the module exactly, 'sendbird' instead of 'SendBird'.

Caused me a lot of difficulty when trying to deploy to Heroku, works perfectly with just this change. Saw a couple other posts of people having the same problem so figured this could help some people.