### PR TITLE
edit declare file (createdAt in BaseChannel)

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -398,7 +398,7 @@ declare namespace SendBird {
     customType: string;
     isFrozen: boolean;
     isEphemeral: boolean;
-    createdAt: string;
+    createdAt: number;
 
     isGroupChannel(): boolean;
     isOpenChannel(): boolean;


### PR DESCRIPTION
I found type bug. 
BaseChannel interface has createdAt. but it's type is string.
Other createdAt is in interface BaseMessageInstance. and its type is number.

Then, i edit BaseChannel's createdAt type.